### PR TITLE
Replace abandoned fabpot/php-cs-fixer with friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		}
 	},
 	"require": {
-		"fabpot/php-cs-fixer": "~1.11",
+		"friendsofphp/php-cs-fixer": "~1.11",
 		"jakub-onderka/php-parallel-lint": "~0.9",
 		"phpmd/phpmd": "~2.0",
 		"squizlabs/php_codesniffer": "2.3.2"


### PR DESCRIPTION
Hello boys, I want to use coding-standards for another project and composer says: "Package fabpot/php-cs-fixer is abandoned, you should avoid using it. Use friendsofphp/php-cs-fixer instead." I tried to replace it and it seems ok :)
