### PR TITLE
Replace some rules of phpmd by phpcs sniffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - `OrmJoinColumnRequireNullableFixer` marked as *risky* (@sustmi)
+- dropped support of PHP 7.0 (@vitek-rostislav)
 
 ## [3.1.1] - 2017-10-31
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         "friendsofphp/php-cs-fixer": "^2.9",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "phpmd/phpmd": "^2.6",
-        "squizlabs/php_codesniffer": "^3.2"
+        "squizlabs/php_codesniffer": "^3.2",
+        "object-calisthenics/phpcs-calisthenics-rules": "^3.1",
+        "slevomat/coding-standard": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "friendsofphp/php-cs-fixer": "^2.9",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "phpmd/phpmd": "^2.6",

--- a/rulesetCS.xml
+++ b/rulesetCS.xml
@@ -63,4 +63,15 @@
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
     <rule ref="src/Sniffs/ForbiddenExitSniff.php"/>
     <rule ref="src/Sniffs/ForbiddenSuperGlobalSniff.php"/>
+
+    <!-- Rules from ObjectCalisthenic package -->
+    <rule ref="vendor/object-calisthenics/phpcs-calisthenics-rules/src/ObjectCalisthenics/Sniffs/NamingConventions/ElementNameMinimalLengthSniff.php">
+        <properties>
+            <property name="minLength" value="2"/>
+        </properties>
+    </rule>
+
+    <!-- Rules from Slevomat Coding Standard package -->
+    <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Classes/UnusedPrivateElementsSniff.php"/>
+
 </ruleset>

--- a/rulesetMD.xml
+++ b/rulesetMD.xml
@@ -29,17 +29,4 @@
 
     <rule ref="rulesets/controversial.xml/CamelCaseParameterName" />
 
-    <rule ref="rulesets/naming.xml/ShortVariable">
-        <properties>
-            <property name="minimum" value="2"/>
-        </properties>
-    </rule>
-
-    <rule ref="rulesets/naming.xml/ShortMethodName">
-        <properties>
-            <property name="minimum" value="2"/>
-        </properties>
-    </rule>
-
-    <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod" />
 </ruleset>


### PR DESCRIPTION
**Description, reason for the PR:** I want to get rid of the phpmd from the package. This is first step towards it - there are added new dependencies that provide sniffs for phpmd. It was necessary to drop support of php 7.0.

**New feature:** No

**BC breaks:** No

**Fixes issues:** First step for resolving issue #7 

**Standards and tests pass:** Yes

**Licence:** MIT
